### PR TITLE
Fixes assertion: continuationFreezeThaw.cpp:231

### DIFF
--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -1624,7 +1624,7 @@ static void gen_continuation_yield(MacroAssembler* masm,
 
   __ load_const_optimized(Rtmp, last_java_pc);
   __ set_last_Java_frame(Z_SP, Rtmp);
-  __ call_VM_leaf(Continuation::freeze_entry(), Z_thread); // FIXME: this is problematic
+  __ call_VM_leaf(Continuation::freeze_entry(), Z_thread, Z_SP); // FIXME: this is problematic
   __ reset_last_Java_frame();
 
   Label L_pinned;

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -1613,7 +1613,6 @@ static void gen_continuation_yield(MacroAssembler* masm,
   DEBUG_ONLY(__ block_comment("Frame Complete"));
   frame_complete = __ pc() - start;
   address last_java_pc = __ pc();
-  __ get_PC(Z_ARG1);
 
   // This nop must be exactly at the PC we push into the frame info.
   // We use this nop for fast CodeBlob lookup, associate the OopMap
@@ -1622,6 +1621,7 @@ static void gen_continuation_yield(MacroAssembler* masm,
   OopMap* map = new OopMap(framesize_bytes / VMRegImpl::stack_slot_size, 1);
   oop_maps->add_gc_map(last_java_pc - start, map);
 
+  __ load_const_optimized(Z_ARG1, last_java_pc);
   __ set_last_Java_frame(Z_SP, Z_ARG1);
   __ call_VM_leaf(Continuation::freeze_entry(), Z_thread); // FIXME: this is problematic
   __ reset_last_Java_frame();

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -1624,7 +1624,7 @@ static void gen_continuation_yield(MacroAssembler* masm,
 
   __ load_const_optimized(Rtmp, last_java_pc);
   __ set_last_Java_frame(Z_SP, Rtmp);
-  __ call_VM_leaf(Continuation::freeze_entry(), Z_thread, Z_SP); // FIXME: this is problematic
+  __ call_VM_leaf(Continuation::freeze_entry(), Z_thread, Z_SP);
   __ reset_last_Java_frame();
 
   Label L_pinned;

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -1598,6 +1598,7 @@ static void gen_continuation_yield(MacroAssembler* masm,
                                    int& frame_complete,
                                    int& framesize_words,
                                    int& compiled_entry_offset) {
+  Register Rtmp = Z_R0_scratch;
   const int framesize_bytes = (int)align_up((int)frame::z_abi_160_base_size, frame::alignment_in_bytes);
   framesize_words = framesize_bytes / wordSize;
 
@@ -1621,8 +1622,8 @@ static void gen_continuation_yield(MacroAssembler* masm,
   OopMap* map = new OopMap(framesize_bytes / VMRegImpl::stack_slot_size, 1);
   oop_maps->add_gc_map(last_java_pc - start, map);
 
-  __ load_const_optimized(Z_ARG1, last_java_pc);
-  __ set_last_Java_frame(Z_SP, Z_ARG1);
+  __ load_const_optimized(Rtmp, last_java_pc);
+  __ set_last_Java_frame(Z_SP, Rtmp);
   __ call_VM_leaf(Continuation::freeze_entry(), Z_thread); // FIXME: this is problematic
   __ reset_last_Java_frame();
 

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -228,7 +228,8 @@ template<typename ConfigT> static inline intptr_t* thaw_internal(JavaThread* thr
 // Called from gen_continuation_yield() in sharedRuntime_<cpu>.cpp through Continuation::freeze_entry();
 template<typename ConfigT>
 static JRT_BLOCK_ENTRY(int, freeze(JavaThread* current, intptr_t* sp))
-  assert(sp == current->frame_anchor()->last_Java_sp(), "");
+  assert(sp == current->frame_anchor()->last_Java_sp(),
+  "Expected stack pointer (" INTPTR_FORMAT ") to equal last_Java_sp (" INTPTR_FORMAT ").", (long unsigned int)sp, (long unsigned int)current->frame_anchor()->last_Java_sp());
 
   if (current->raw_cont_fastpath() > current->last_continuation()->entry_sp() || current->raw_cont_fastpath() < sp) {
     current->set_cont_fastpath(nullptr);

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -229,7 +229,7 @@ template<typename ConfigT> static inline intptr_t* thaw_internal(JavaThread* thr
 template<typename ConfigT>
 static JRT_BLOCK_ENTRY(int, freeze(JavaThread* current, intptr_t* sp))
   assert(sp == current->frame_anchor()->last_Java_sp(),
-  "Expected stack pointer (" INTPTR_FORMAT ") to equal last_Java_sp (" INTPTR_FORMAT ").", (long unsigned int)sp, (long unsigned int)current->frame_anchor()->last_Java_sp());
+  "Expected stack pointer (" INTPTR_FORMAT ") to equal last_Java_sp (" INTPTR_FORMAT ").", p2i(sp), p2i(current->frame_anchor()->last_Java_sp()));
 
   if (current->raw_cont_fastpath() > current->last_continuation()->entry_sp() || current->raw_cont_fastpath() < sp) {
     current->set_cont_fastpath(nullptr);


### PR DESCRIPTION
Fixes the following assertion by modifying the call in `gen_continuation_yield`.

```
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/home/ty/openjdk/jdk-amit/src/hotspot/share/runtime/continuationFreezeThaw.cpp:231), pid=536749, tid=536779
#  Error: assert(sp == current->frame_anchor()->last_Java_sp()) failed
```

Summary of changes:
- Replace `getPC` with `load_const_optimized`
- Preserve value of `Z_ARG1` which may contain the value of an argument to a java call
- Add register `tmp` variable
- Adds 3rd argument to call (was previously set to nullptr)

Please review and merge at your discression @offamitkumar.