### PR TITLE
Fix infinite loop with RR's suggested improvement

### DIFF
--- a/src/hotspot/cpu/s390/frame_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.inline.hpp
@@ -360,7 +360,7 @@ inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
 }
 
 inline int frame::sender_sp_ret_address_offset() {
-  return -(int)(z_abi(return_pc) >> LogBytesPerWord); // offset in words
+  return -(int)(_z_abi(return_pc) >> LogBytesPerWord); // offset in words
 }
 
 //------------------------------------------------------------------------------

--- a/src/hotspot/cpu/s390/frame_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.inline.hpp
@@ -360,8 +360,7 @@ inline void frame::interpreted_frame_oop_map(InterpreterOopMap* mask) const {
 }
 
 inline int frame::sender_sp_ret_address_offset() {
-  Unimplemented();
-  return 0;
+  return -(int)(z_abi(return_pc) >> LogBytesPerWord); // offset in words
 }
 
 //------------------------------------------------------------------------------

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -1609,7 +1609,7 @@ static void gen_continuation_yield(MacroAssembler* masm,
   // not sure what to do with __ enter(), Other places where this was
   // used s390x seems doing nothing.
   __ save_return_pc(Z_R14);
-  __ push_frame(framesize_bytes, Z_SP);
+  __ push_frame(framesize_bytes, Rtmp);
 
   DEBUG_ONLY(__ block_comment("Frame Complete"));
   frame_complete = __ pc() - start;

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -1599,8 +1599,6 @@ static void gen_continuation_yield(MacroAssembler* masm,
                                    int& framesize_words,
                                    int& compiled_entry_offset) {
   Register Rtmp = Z_R0_scratch;
-  const int framesize_bytes = (int)align_up((int)frame::z_abi_160_base_size, frame::alignment_in_bytes);
-  framesize_words = framesize_bytes / wordSize;
 
   address start = __ pc();
   compiled_entry_offset = __ pc() - start;
@@ -1609,7 +1607,8 @@ static void gen_continuation_yield(MacroAssembler* masm,
   // not sure what to do with __ enter(), Other places where this was
   // used s390x seems doing nothing.
   __ save_return_pc(Z_R14);
-  __ push_frame(framesize_bytes, Rtmp);
+  const int framesize_bytes = __ push_frame_abi160(0);
+  framesize_words = framesize_bytes / wordSize;
 
   DEBUG_ONLY(__ block_comment("Frame Complete"));
   frame_complete = __ pc() - start;


### PR DESCRIPTION
As explained [on ZenHub](https://github.ibm.com/runtimes/openjdk-issue-tracking/issues/127#issuecomment-57835260), RR's intuition was good about this loop.

This PR makes the following changes:
- Accept RR's suggestion. Fixes loop.
- Implement frame::sender_sp_ret_address_offset, using the ppc impl as a guide. Fixes subsequent failure due to `Unimplemented()` in `assert_entry_frame_laid_out` call.

```
#  Internal Error (/home/ty/openjdk/jdk-amit/src/hotspot/share/compiler/oopMap.cpp:717), pid=638677, tid=638708
#  guarantee(last != nullptr) failed: last may not be null
#
# JRE version: OpenJDK Runtime Environment (21.0) (fastdebug build 21-internal-adhoc.ty.jdk-amit)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 21-internal-adhoc.ty.jdk-amit, mixed mode, tiered, compressed oops, compressed class ptrs, g1 gc, linux-s390x)
# Problematic frame:
# V  [libjvm.so+0xf517de]  ImmutableOopMapSet::find_map_at_offset(int) const+0x66
```